### PR TITLE
Fix runtime blocker precedence

### DIFF
--- a/docs/issues/harness-observations.json
+++ b/docs/issues/harness-observations.json
@@ -182,6 +182,26 @@
       "closureCondition": [
         "The repo can generate and accept a next milestone proposal after the current final milestone is fully verified, and the workflow is documented for orchestrator use."
       ]
+    },
+    {
+      "number": 19,
+      "title": "Runtime misclassifies policy rejections as read-only blockers",
+      "batch": "followup",
+      "status": "landed",
+      "summary": "Make runtime blocker classification precedence-aware so explicit policy and helper-launch rejections win over generic read-only or write-capability text.",
+      "linkedIssues": [15],
+      "repoEvidence": [
+        "The runtime already classifies blockers from last-message, stdout event output, and stderr text.",
+        "Generic write-capability wording can coexist with more specific policy or helper-launch failures in the same runtime cycle."
+      ],
+      "implementationNotes": [
+        "Move blocker classification into a dedicated helper module so it can be verified directly.",
+        "Prioritize policy rejection and helper-launch failure patterns before read-only and write-capability patterns.",
+        "Treat helper-launch cancellation and ShellExecuteExW setup-helper failures as policy-side blockers for operator diagnostics."
+      ],
+      "closureCondition": [
+        "Runtime status reports policy-side failures as policy-rejection instead of workspace-read-only when both kinds of text appear together."
+      ]
     }
   ]
 }

--- a/docs/issues/harness/README.md
+++ b/docs/issues/harness/README.md
@@ -13,4 +13,5 @@ Generated from `docs/issues/harness-observations.json`.
 | [#14](https://github.com/dawid0309/Codex-Harness-Foundry/issues/14) | Detached runtime inherits global shell and Codex state noise | followup | landed | [draft](./issue-14.md) |
 | [#15](https://github.com/dawid0309/Codex-Harness-Foundry/issues/15) | Runtime keeps looping after repeated unrecoverable blockers | followup | landed | [draft](./issue-15.md) |
 | [#17](https://github.com/dawid0309/Codex-Harness-Foundry/issues/17) | Propose the next milestone when the final milestone is fully verified | followup | landed | [draft](./issue-17.md) |
+| [#19](https://github.com/dawid0309/Codex-Harness-Foundry/issues/19) | Runtime misclassifies policy rejections as read-only blockers | followup | landed | [draft](./issue-19.md) |
 

--- a/docs/issues/harness/issue-19.md
+++ b/docs/issues/harness/issue-19.md
@@ -1,0 +1,25 @@
+# Issue #19: Runtime misclassifies policy rejections as read-only blockers
+
+- Batch: followup
+- Status: landed
+- Linked issues: [#15](https://github.com/dawid0309/Codex-Harness-Foundry/issues/15)
+
+## Summary
+
+Make runtime blocker classification precedence-aware so explicit policy and helper-launch rejections win over generic read-only or write-capability text.
+
+## Repo Evidence
+
+- The runtime already classifies blockers from last-message, stdout event output, and stderr text.
+- Generic write-capability wording can coexist with more specific policy or helper-launch failures in the same runtime cycle.
+
+## Implementation Notes
+
+- Move blocker classification into a dedicated helper module so it can be verified directly.
+- Prioritize policy rejection and helper-launch failure patterns before read-only and write-capability patterns.
+- Treat helper-launch cancellation and ShellExecuteExW setup-helper failures as policy-side blockers for operator diagnostics.
+
+## Closure Condition
+
+- Runtime status reports policy-side failures as policy-rejection instead of workspace-read-only when both kinds of text appear together.
+

--- a/docs/runbooks/runtime-control.md
+++ b/docs/runbooks/runtime-control.md
@@ -59,4 +59,6 @@ The runtime treats repeated unrecoverable conditions as terminal blockers, inclu
 - approval or policy rejections
 - required repo commands that are not executable
 
+Classification is precedence-aware: explicit policy rejection and helper-launch failures are reported before generic read-only or write-capability wording so runtime status reflects the upstream blocker more accurately.
+
 When the same blocker repeats for the configured number of cycles, the runtime moves to `blocked` instead of looping indefinitely. Use `pnpm runtime:resume` after fixing the underlying repo or policy constraint.

--- a/scripts/runtime-blockers.ts
+++ b/scripts/runtime-blockers.ts
@@ -1,0 +1,69 @@
+export type TerminalBlocker = {
+  signature: string;
+  label: string;
+};
+
+type RuntimeBlockerMatcher = TerminalBlocker & {
+  patterns: RegExp[];
+};
+
+const blockerMatchers: RuntimeBlockerMatcher[] = [
+  {
+    signature: "policy-rejection",
+    label: "approval or policy rejection prevents progress",
+    patterns: [
+      /approval policy/i,
+      /requires approval/i,
+      /blocked by policy/i,
+      /policy rejection/i,
+      /not permitted by policy/i,
+      /orchestrator_helper_launch_canceled/i,
+      /ShellExecuteExW failed to launch setup helper/i,
+      /\b1223\b/,
+    ],
+  },
+  {
+    signature: "workspace-read-only",
+    label: "workspace or sandbox is read-only",
+    patterns: [
+      /workspace is read-only/i,
+      /read-only workspace/i,
+      /workspace remains read-only/i,
+      /sandbox.*read-only/i,
+      /cannot write (files|changes|to)/i,
+      /no writable/i,
+      /missing write capability/i,
+      /write capability/i,
+    ],
+  },
+  {
+    signature: "command-not-executable",
+    label: "required planner or repo command is not executable",
+    patterns: [
+      /pnpm planner:propose.*not executable/i,
+      /pnpm planner:publish.*not executable/i,
+      /pnpm next-milestone:propose.*not executable/i,
+      /pnpm next-milestone:publish.*not executable/i,
+      /command .* not executable/i,
+    ],
+  },
+];
+
+export function detectTerminalBlocker(
+  lastMessage: string,
+  stdoutText: string,
+  stderrText: string,
+): TerminalBlocker | null {
+  const text = `${lastMessage}\n${stdoutText}\n${stderrText}`;
+
+  for (const matcher of blockerMatchers) {
+    if (matcher.patterns.some((pattern) => pattern.test(text))) {
+      return {
+        signature: matcher.signature,
+        label: matcher.label,
+      };
+    }
+  }
+
+  return null;
+}

--- a/scripts/runtime.ts
+++ b/scripts/runtime.ts
@@ -11,6 +11,7 @@ import {
   type AutonomyConfig,
   type StopConditionId,
 } from "./project-config";
+import { detectTerminalBlocker, type TerminalBlocker } from "./runtime-blockers";
 
 type RuntimeState =
   | "idle"
@@ -52,11 +53,6 @@ type TaskBoardTask = {
 type TaskBoard = {
   currentMilestoneId?: string;
   tasks?: TaskBoardTask[];
-};
-
-type TerminalBlocker = {
-  signature: string;
-  label: string;
 };
 
 type CycleResult = {
@@ -408,58 +404,6 @@ function trimBuffer(buffer: string, maxChars = 12000) {
 
 async function appendLog(filePath: string, chunk: string) {
   await appendFile(filePath, chunk, "utf8");
-}
-
-function detectTerminalBlocker(lastMessage: string, stdoutText: string, stderrText: string): TerminalBlocker | null {
-  const text = `${lastMessage}\n${stdoutText}\n${stderrText}`;
-
-  const matchers: Array<TerminalBlocker & { patterns: RegExp[] }> = [
-    {
-      signature: "workspace-read-only",
-      label: "workspace or sandbox is read-only",
-      patterns: [
-        /workspace is read-only/i,
-        /read-only workspace/i,
-        /workspace remains read-only/i,
-        /sandbox.*read-only/i,
-        /cannot write (files|changes|to)/i,
-        /no writable/i,
-        /missing write capability/i,
-        /write capability/i,
-      ],
-    },
-    {
-      signature: "policy-rejection",
-      label: "approval or policy rejection prevents progress",
-      patterns: [
-        /approval policy/i,
-        /requires approval/i,
-        /blocked by policy/i,
-        /policy rejection/i,
-        /not permitted by policy/i,
-      ],
-    },
-    {
-      signature: "command-not-executable",
-      label: "required planner or repo command is not executable",
-      patterns: [
-        /pnpm planner:propose.*not executable/i,
-        /pnpm planner:publish.*not executable/i,
-        /command .* not executable/i,
-      ],
-    },
-  ];
-
-  for (const matcher of matchers) {
-    if (matcher.patterns.some((pattern) => pattern.test(text))) {
-      return {
-        signature: matcher.signature,
-        label: matcher.label,
-      };
-    }
-  }
-
-  return null;
 }
 
 function extractRuntimeEventText(event: RuntimeEvent): string {


### PR DESCRIPTION
## Summary
- move runtime blocker detection into a dedicated helper module
- classify policy rejection and helper-launch failures before generic read-only or write-capability text
- document the precedence rule and export the repo-owned issue artifact for #19

## Verification
- pnpm run typecheck
- pnpm exec tsx -e "...detectTerminalBlocker(existing runtime logs + helper-launch stderr)..." => policy-rejection
- pnpm exec tsx -e "...detectTerminalBlocker('missing write capability and blocked by policy')..." => policy-rejection

Closes #19