### PR TITLE
Harden Windows detached runtime startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ For longer Codex CLI runs, the template can supervise a background session with 
 
 - Configure runtime behavior in `project.config.json.autonomy`
 - Detached runs use a repo-scoped Codex home under `data/runtime/codex-home/` to avoid inheriting workstation-global Codex state
+- On Windows, detached runtime sessions fall back from `workspace-write` to `danger-full-access` so shell startup can reach repo commands reliably
 - Start with `pnpm runtime:start`
 - Check state with `pnpm runtime:status`
 - Stop or resume with `pnpm runtime:stop` and `pnpm runtime:resume`

--- a/docs/issues/harness-observations.json
+++ b/docs/issues/harness-observations.json
@@ -202,6 +202,26 @@
       "closureCondition": [
         "Runtime status reports policy-side failures as policy-rejection instead of workspace-read-only when both kinds of text appear together."
       ]
+    },
+    {
+      "number": 21,
+      "title": "Windows detached runtime sandbox breaks shell startup and can false-complete",
+      "batch": "followup",
+      "status": "landed",
+      "summary": "Make the Windows detached runtime resilient to shell-sandbox startup failures and forbid completed status when no repo-local command actually ran.",
+      "linkedIssues": [19],
+      "repoEvidence": [
+        "Detached runtime shell startup can fail on Windows before any repository command executes.",
+        "Structural stop predicates alone are not enough to prove useful runtime progress if the cycle never reaches repo-local command execution."
+      ],
+      "implementationNotes": [
+        "Keep CODEX_HOME repo-scoped but preserve the real Windows profile directories for detached runs.",
+        "Fall back from workspace-write to danger-full-access for Windows detached runtime sessions so shell startup can reach repo commands reliably.",
+        "Classify shell-startup failures explicitly and prevent completed state when a cycle exits before any repo-local command executes."
+      ],
+      "closureCondition": [
+        "Windows detached runtime status reports shell-startup failures accurately and no longer enters completed when a cycle never executes a repo-local command."
+      ]
     }
   ]
 }

--- a/docs/issues/harness/README.md
+++ b/docs/issues/harness/README.md
@@ -14,4 +14,5 @@ Generated from `docs/issues/harness-observations.json`.
 | [#15](https://github.com/dawid0309/Codex-Harness-Foundry/issues/15) | Runtime keeps looping after repeated unrecoverable blockers | followup | landed | [draft](./issue-15.md) |
 | [#17](https://github.com/dawid0309/Codex-Harness-Foundry/issues/17) | Propose the next milestone when the final milestone is fully verified | followup | landed | [draft](./issue-17.md) |
 | [#19](https://github.com/dawid0309/Codex-Harness-Foundry/issues/19) | Runtime misclassifies policy rejections as read-only blockers | followup | landed | [draft](./issue-19.md) |
+| [#21](https://github.com/dawid0309/Codex-Harness-Foundry/issues/21) | Windows detached runtime sandbox breaks shell startup and can false-complete | followup | landed | [draft](./issue-21.md) |
 

--- a/docs/issues/harness/issue-21.md
+++ b/docs/issues/harness/issue-21.md
@@ -1,0 +1,25 @@
+# Issue #21: Windows detached runtime sandbox breaks shell startup and can false-complete
+
+- Batch: followup
+- Status: landed
+- Linked issues: [#19](https://github.com/dawid0309/Codex-Harness-Foundry/issues/19)
+
+## Summary
+
+Make the Windows detached runtime resilient to shell-sandbox startup failures and forbid completed status when no repo-local command actually ran.
+
+## Repo Evidence
+
+- Detached runtime shell startup can fail on Windows before any repository command executes.
+- Structural stop predicates alone are not enough to prove useful runtime progress if the cycle never reaches repo-local command execution.
+
+## Implementation Notes
+
+- Keep CODEX_HOME repo-scoped but preserve the real Windows profile directories for detached runs.
+- Fall back from workspace-write to danger-full-access for Windows detached runtime sessions so shell startup can reach repo commands reliably.
+- Classify shell-startup failures explicitly and prevent completed state when a cycle exits before any repo-local command executes.
+
+## Closure Condition
+
+- Windows detached runtime status reports shell-startup failures accurately and no longer enters completed when a cycle never executes a repo-local command.
+

--- a/docs/runbooks/runtime-control.md
+++ b/docs/runbooks/runtime-control.md
@@ -26,9 +26,11 @@ Runtime state is stored in ignored files under `data/runtime/`.
 - `data/runtime/codex-runtime-stderr.log`
 - `data/runtime/codex-runtime-last-message.txt`
 
-The status file records the runtime state, worker and child process ids, thread id, heartbeat, selected stop condition, runtime home, terminal blocker streak, and latest result summary.
+The status file records the runtime state, worker and child process ids, thread id, heartbeat, selected stop condition, runtime home, terminal blocker streak, effective detached sandbox mode, whether the last cycle executed a repo-local command, and latest result summary.
 
 Detached runs use a repo-scoped Codex home under `data/runtime/codex-home/`. This keeps the runtime from inheriting workstation-global Codex state, shell profiles, or unrelated local noise when it starts in the background.
+
+On Windows, detached runtime sessions keep the real profile directories intact. When the configured detached sandbox is `workspace-write`, the runtime falls back to `danger-full-access` for the detached Codex process so shell startup can reach repo commands reliably.
 
 ## Structural Stop Conditions
 
@@ -55,10 +57,13 @@ Configure the blocker budget in `project.config.json.autonomy.maxConsecutiveTerm
 
 The runtime treats repeated unrecoverable conditions as terminal blockers, including:
 
+- shell startup failures before any repo-local command can run
 - read-only workspace or sandbox restrictions
 - approval or policy rejections
 - required repo commands that are not executable
 
 Classification is precedence-aware: explicit policy rejection and helper-launch failures are reported before generic read-only or write-capability wording so runtime status reflects the upstream blocker more accurately.
+
+The runtime also refuses to report `completed` when a cycle exits before any repo-local command executes, even if the structural stop predicate already evaluates true.
 
 When the same blocker repeats for the configured number of cycles, the runtime moves to `blocked` instead of looping indefinitely. Use `pnpm runtime:resume` after fixing the underlying repo or policy constraint.

--- a/scripts/runtime-blockers.ts
+++ b/scripts/runtime-blockers.ts
@@ -9,6 +9,18 @@ type RuntimeBlockerMatcher = TerminalBlocker & {
 
 const blockerMatchers: RuntimeBlockerMatcher[] = [
   {
+    signature: "shell-startup-failure",
+    label: "shell startup failed before repo commands could run",
+    patterns: [
+      /CreateProcessWithLogonW failed:\s*1326/i,
+      /0x8009001d/i,
+      /\b8009001d\b/i,
+      /Windows PowerShell startup failure/i,
+      /shell startup failure/i,
+      /failed before any repo command executes/i,
+    ],
+  },
+  {
     signature: "policy-rejection",
     label: "approval or policy rejection prevents progress",
     patterns: [

--- a/scripts/runtime.ts
+++ b/scripts/runtime.ts
@@ -43,6 +43,8 @@ type RuntimeStatus = {
   lastBlockerSignature: string | null;
   maxConsecutiveTerminalBlockers: number;
   lastExitCode: number | null;
+  effectiveSandboxMode: string;
+  lastCycleExecutedRepoCommand: boolean;
 };
 
 type TaskBoardTask = {
@@ -61,6 +63,8 @@ type CycleResult = {
   stdoutText: string;
   stderrText: string;
   blocker: TerminalBlocker | null;
+  executedRepoCommand: boolean;
+  effectiveSandboxMode: string;
 };
 
 type RuntimeEvent = {
@@ -136,6 +140,8 @@ function defaultStatus(config: AutonomyConfig = defaultAutonomyConfig()): Runtim
     lastBlockerSignature: null,
     maxConsecutiveTerminalBlockers: Math.max(1, config.maxConsecutiveTerminalBlockers),
     lastExitCode: null,
+    effectiveSandboxMode: config.sandboxMode,
+    lastCycleExecutedRepoCommand: false,
   };
 }
 
@@ -352,8 +358,6 @@ function buildRuntimeEnvironment(): NodeJS.ProcessEnv {
   }
 
   env.CODEX_HOME = runtimeCodexHomePath;
-  env.HOME = runtimeCodexHomePath;
-  env.USERPROFILE = runtimeCodexHomePath;
   env[runtimeSourceConfigEnv] = path.join(process.env.USERPROFILE ?? os.homedir(), ".codex", "config.toml");
   env.POWERSHELL_TELEMETRY_OPTOUT = "1";
   env.GIT_TERMINAL_PROMPT = "0";
@@ -369,11 +373,19 @@ function buildRuntimeEnvironment(): NodeJS.ProcessEnv {
   return env;
 }
 
-function buildCodexArgs(status: RuntimeStatus, config: AutonomyConfig): string[] {
+function detachedSandboxMode(config: AutonomyConfig): string {
+  if (process.platform === "win32" && config.sandboxMode === "workspace-write") {
+    return "danger-full-access";
+  }
+
+  return config.sandboxMode;
+}
+
+function buildCodexArgs(status: RuntimeStatus, config: AutonomyConfig, effectiveSandboxMode: string): string[] {
   const args: string[] = ["-c", "shell_environment_policy.inherit=none"];
 
   if (!status.threadId) {
-    args.push("exec", "--json", "-C", root, "-s", config.sandboxMode, "-o", lastMessagePath);
+    args.push("exec", "--json", "-C", root, "-s", effectiveSandboxMode, "-o", lastMessagePath);
     if (config.model) {
       args.push("-m", config.model);
     }
@@ -433,7 +445,8 @@ function extractRuntimeEventText(event: RuntimeEvent): string {
 
 async function runCodexCycle(status: RuntimeStatus, config: AutonomyConfig): Promise<CycleResult> {
   const prompt = runtimePrompt(status.threadId ? config.resumePrompt : config.basePrompt);
-  const args = buildCodexArgs(status, config);
+  const effectiveSandboxMode = detachedSandboxMode(config);
+  const args = buildCodexArgs(status, config, effectiveSandboxMode);
   const env = buildRuntimeEnvironment();
 
   const child = spawn(codexCommand(), args, {
@@ -454,6 +467,7 @@ async function runCodexCycle(status: RuntimeStatus, config: AutonomyConfig): Pro
       issueExportDirectory: config.issueExportDirectory,
       runtimeCodexHome: path.relative(root, runtimeCodexHomePath),
       environmentMode: "repo-scoped",
+      effectiveSandboxMode,
     }),
     config,
   );
@@ -465,6 +479,7 @@ async function runCodexCycle(status: RuntimeStatus, config: AutonomyConfig): Pro
   let stdoutBuffer = "";
   let stdoutSignalsBuffer = "";
   let stderrBuffer = "";
+  let executedRepoCommand = false;
 
   const processStdoutLine = async (line: string) => {
     const trimmed = line.trim();
@@ -474,6 +489,17 @@ async function runCodexCycle(status: RuntimeStatus, config: AutonomyConfig): Pro
 
     try {
       const event = JSON.parse(trimmed) as RuntimeEvent;
+      if (event.item?.type === "command_execution") {
+        const normalizedCommand = event.item.command?.replace(/\\/g, "/") ?? "";
+        const normalizedRoot = root.replace(/\\/g, "/");
+        if (
+          normalizedCommand.includes(normalizedRoot) ||
+          /project\.config\.json|planning\/|docs\/architecture\/|agents-md\/|AGENTS\.md|data\/runtime\//i.test(normalizedCommand)
+        ) {
+          executedRepoCommand = true;
+        }
+      }
+
       const eventText = extractRuntimeEventText(event);
       if (eventText) {
         stdoutSignalsBuffer = trimBuffer(`${stdoutSignalsBuffer}\n${eventText}`);
@@ -546,6 +572,8 @@ async function runCodexCycle(status: RuntimeStatus, config: AutonomyConfig): Pro
     stdoutText: stdoutSignalsBuffer.trim(),
     stderrText: stderrBuffer,
     blocker,
+    executedRepoCommand,
+    effectiveSandboxMode,
   };
 }
 
@@ -557,6 +585,10 @@ function nextStateForCycle(
 ): RuntimeState {
   if (cycleResult.exitCode !== 0) {
     return "failed";
+  }
+
+  if (!cycleResult.executedRepoCommand) {
+    return cycleResult.blocker && blockerCount >= blockerBudget ? "blocked" : "failed";
   }
 
   if (matchedStopCondition) {
@@ -583,6 +615,12 @@ function resultSummary(
     return cycleResult.blocker
       ? `Codex CLI exited with code ${cycleResult.exitCode}. Terminal blocker detected: ${cycleResult.blocker.label}.`
       : `Codex CLI exited with code ${cycleResult.exitCode}.`;
+  }
+
+  if (!cycleResult.executedRepoCommand) {
+    return cycleResult.blocker
+      ? `Codex CLI did not successfully execute a repo-local command. Terminal blocker detected: ${cycleResult.blocker.label}.`
+      : "Codex CLI exited without successfully executing a repo-local command.";
   }
 
   if (nextState === "blocked" && cycleResult.blocker) {
@@ -625,6 +663,7 @@ async function runWorker() {
       runtimeCodexHome: path.relative(root, runtimeCodexHomePath),
       environmentMode: "repo-scoped",
       maxConsecutiveTerminalBlockers: Math.max(1, config.maxConsecutiveTerminalBlockers),
+      effectiveSandboxMode: detachedSandboxMode(config),
     }),
     config,
   );
@@ -672,6 +711,8 @@ async function runWorker() {
         lastExitCode: cycleResult.exitCode,
         runtimeCodexHome: path.relative(root, runtimeCodexHomePath),
         environmentMode: "repo-scoped",
+        effectiveSandboxMode: cycleResult.effectiveSandboxMode,
+        lastCycleExecutedRepoCommand: cycleResult.executedRepoCommand,
       }),
       config,
     );
@@ -711,6 +752,7 @@ async function spawnWorker(mode: "start" | "resume") {
           state: "starting",
           startTime: nowIso(),
           lastHeartbeat: nowIso(),
+          effectiveSandboxMode: detachedSandboxMode(config),
         }
       : {
           ...status,
@@ -719,6 +761,8 @@ async function spawnWorker(mode: "start" | "resume") {
           consecutiveTerminalBlockers: 0,
           lastBlockerSignature: null,
           lastExitCode: null,
+          effectiveSandboxMode: detachedSandboxMode(config),
+          lastCycleExecutedRepoCommand: false,
         };
 
   if (mode === "start") {
@@ -747,6 +791,7 @@ async function spawnWorker(mode: "start" | "resume") {
           : "Background runtime resumed with repo-scoped Codex home.",
       runtimeCodexHome: path.relative(root, runtimeCodexHomePath),
       environmentMode: "repo-scoped",
+      effectiveSandboxMode: detachedSandboxMode(config),
     }),
     config,
   );
@@ -786,6 +831,8 @@ async function commandStatus() {
   console.log(`Issue export directory: ${effectiveStatus.issueExportDirectory}`);
   console.log(`Runtime Codex home: ${effectiveStatus.runtimeCodexHome}`);
   console.log(`Environment mode: ${effectiveStatus.environmentMode}`);
+  console.log(`Effective sandbox mode: ${effectiveStatus.effectiveSandboxMode}`);
+  console.log(`Last cycle executed repo command: ${effectiveStatus.lastCycleExecutedRepoCommand}`);
   console.log(`Terminal blocker streak: ${effectiveStatus.consecutiveTerminalBlockers}/${effectiveStatus.maxConsecutiveTerminalBlockers}`);
   console.log(`Last blocker signature: ${effectiveStatus.lastBlockerSignature ?? "n/a"}`);
   console.log(`Latest result: ${effectiveStatus.latestResultSummary ?? "n/a"}`);


### PR DESCRIPTION
## Summary
- preserve the real Windows profile directories while keeping `CODEX_HOME` repo-scoped for detached runtime sessions
- fall back from `workspace-write` to `danger-full-access` for Windows detached runtime startup
- add `shell-startup-failure` classification and block false `completed` status when no repo-local command executed

## Verification
- pnpm run typecheck
- focused Windows fallback check => `workspace-write` resolves to `danger-full-access`
- focused next-state check => no repo-local command + matched stop condition resolves to `failed`, not `completed`
- focused blocker check => `1326` / `8009001d` resolves to `shell-startup-failure`

Closes #21