### PR TITLE
Add generic runtime supervisor and watch commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ Full reference:
 | `pnpm runtime:status` | Inspect runtime state from `data/runtime/` |
 | `pnpm runtime:stop` | Stop the background runtime and clear active process handles |
 | `pnpm runtime:resume` | Resume a stopped, interrupted, failed, or blocked runtime session |
+| `pnpm runtime:supervise` | Start an outer watchdog that relaunches interrupted runtime workers |
+| `pnpm runtime:supervise:status` | Inspect watchdog state from `data/runtime/supervisor-status.json` |
+| `pnpm runtime:supervise:stop` | Stop the watchdog and the inner runtime together |
+| `pnpm runtime:watch` | Live-watch supervisor state, runtime state, and optional project status output |
 
 ## Repository Layout
 
@@ -247,17 +251,25 @@ The template intentionally owns one source schema, one renderer, and one default
 
 ## Runtime Control
 
-For longer Codex CLI runs, the template can supervise a background session with structural stop conditions.
+For longer Codex CLI runs, the template can supervise a background session with structural stop conditions and an optional outer watchdog for crash recovery.
 
 - Configure runtime behavior in `project.config.json.autonomy`
+- Configure watchdog and hook behavior in `harness.config.json`
 - Detached runs use a repo-scoped Codex home under `data/runtime/codex-home/` to avoid inheriting workstation-global Codex state
 - On Windows, detached runtime sessions fall back from `workspace-write` to `danger-full-access` so shell startup can reach repo commands reliably
 - Start with `pnpm runtime:start`
+- Prefer `pnpm runtime:supervise` if you want the runtime relaunched after interruptions
 - Check state with `pnpm runtime:status`
 - Stop or resume with `pnpm runtime:stop` and `pnpm runtime:resume`
+- Stop or inspect the watchdog with `pnpm runtime:supervise:stop`, `pnpm runtime:supervise:status`, and `pnpm runtime:watch`
 - Set `autonomy.maxConsecutiveTerminalBlockers` if you want repeated policy or sandbox blockers to stop in `blocked` instead of looping
 - When the final milestone is fully verified and no later blueprint exists, the orchestrator should switch to `pnpm next-milestone:propose`
 - Read the [runtime control runbook](./docs/runbooks/runtime-control.md) for the status file and stop-condition details
+
+Downstream projects should keep project-specific behavior out of the template core and inject it with hooks:
+
+- `hooks.postIterationCommand` runs after each completed runtime cycle
+- `hooks.projectStatusCommand` prints repo-specific status inside `pnpm runtime:watch`
 
 ## Planner Publication Model
 

--- a/docs/runbooks/runtime-control.md
+++ b/docs/runbooks/runtime-control.md
@@ -9,9 +9,17 @@ pnpm runtime:start
 pnpm runtime:status
 pnpm runtime:stop
 pnpm runtime:resume
+pnpm runtime:supervise
+pnpm runtime:supervise:status
+pnpm runtime:supervise:stop
+pnpm runtime:watch
 ```
 
 These commands are intentionally Codex-CLI specific. The template uses `codex exec` for the first cycle and `codex exec resume` for follow-up cycles.
+
+- `runtime:start` and `runtime:resume` control the inner detached runtime worker.
+- `runtime:supervise` adds an outer watchdog that can relaunch interrupted or failed runtime workers.
+- `runtime:watch` renders both status layers and optional downstream project status output.
 
 When the runtime needs new work published, the leader/orchestrator should request planner output with `pnpm planner:propose`, inspect `planning/planner-output.json`, and accept it with `pnpm planner:publish` instead of publishing tasks inline.
 
@@ -25,12 +33,55 @@ Runtime state is stored in ignored files under `data/runtime/`.
 - `data/runtime/codex-runtime-stdout.log`
 - `data/runtime/codex-runtime-stderr.log`
 - `data/runtime/codex-runtime-last-message.txt`
+- `data/runtime/supervisor-status.json`
 
-The status file records the runtime state, worker and child process ids, thread id, heartbeat, selected stop condition, runtime home, terminal blocker streak, effective detached sandbox mode, whether the last cycle executed a repo-local command, and latest result summary.
+The runtime status file records the runtime state, worker and child process ids, thread id, heartbeat, selected stop condition, runtime home, terminal blocker streak, effective detached sandbox mode, whether the last cycle executed a repo-local command, the last post-iteration hook result, and the latest result summary.
+
+The supervisor status file records the outer watchdog state, restart counters, next launch time, last launch command, and the latest observed runtime pid/thread.
 
 Detached runs use a repo-scoped Codex home under `data/runtime/codex-home/`. This keeps the runtime from inheriting workstation-global Codex state, shell profiles, or unrelated local noise when it starts in the background.
 
 On Windows, detached runtime sessions keep the real profile directories intact. When the configured detached sandbox is `workspace-write`, the runtime falls back to `danger-full-access` for the detached Codex process so shell startup can reach repo commands reliably.
+
+## Harness Config
+
+Generic watchdog and hook behavior lives in `harness.config.json`.
+
+```json
+{
+  "supervisor": {
+    "childCommand": null,
+    "workdir": ".",
+    "pollIntervalSeconds": 5,
+    "restartBackoffSeconds": 10,
+    "maxRestartsPerHour": 12
+  },
+  "hooks": {
+    "postIterationCommand": null,
+    "projectStatusCommand": null
+  }
+}
+```
+
+- `supervisor.childCommand`: optional override if a downstream repo wants the watchdog to launch a custom command instead of the default `runtime:start` / `runtime:resume` decision.
+- `supervisor.workdir`: working directory for the launched child command.
+- `supervisor.pollIntervalSeconds`: how often the watchdog refreshes status and checks runtime liveness.
+- `supervisor.restartBackoffSeconds`: wait time before retrying a failed launch.
+- `supervisor.maxRestartsPerHour`: hard cap that stops the watchdog instead of looping forever on repeated failures.
+- `hooks.postIterationCommand`: optional command that runs after each completed runtime cycle. Use this for downstream planner/status refresh logic.
+- `hooks.projectStatusCommand`: optional command whose stdout is shown in `pnpm runtime:watch`.
+
+## Downstream Hooks
+
+Keep project-specific behavior in downstream repos, not in the template core.
+
+Recommended pattern:
+
+1. Keep project-specific planner/status logic in repo-local scripts or package commands.
+2. Point `hooks.postIterationCommand` at the downstream planner/status refresh sequence.
+3. Point `hooks.projectStatusCommand` at the downstream status command that prints exactly the fields operators should watch.
+
+That gives downstream repos richer visibility without hardcoding milestone schemas, product names, or repo paths into Foundry.
 
 ## Structural Stop Conditions
 

--- a/harness.config.json
+++ b/harness.config.json
@@ -1,0 +1,13 @@
+{
+  "supervisor": {
+    "childCommand": null,
+    "workdir": ".",
+    "pollIntervalSeconds": 5,
+    "restartBackoffSeconds": 10,
+    "maxRestartsPerHour": 12
+  },
+  "hooks": {
+    "postIterationCommand": null,
+    "projectStatusCommand": null
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,11 @@
     "runtime:start": "tsx scripts/runtime.ts start",
     "runtime:status": "tsx scripts/runtime.ts status",
     "runtime:stop": "tsx scripts/runtime.ts stop",
-    "runtime:resume": "tsx scripts/runtime.ts resume"
+    "runtime:resume": "tsx scripts/runtime.ts resume",
+    "runtime:supervise": "tsx scripts/supervisor.ts start",
+    "runtime:supervise:status": "tsx scripts/supervisor.ts status",
+    "runtime:supervise:stop": "tsx scripts/supervisor.ts stop",
+    "runtime:watch": "tsx scripts/supervisor.ts watch"
   },
   "devDependencies": {
     "@types/node": "^22.14.1",

--- a/scripts/harness-config.ts
+++ b/scripts/harness-config.ts
@@ -1,0 +1,106 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { root } from "./project-config";
+
+export type HarnessSupervisorConfig = {
+  childCommand: string | null;
+  workdir: string;
+  pollIntervalSeconds: number;
+  restartBackoffSeconds: number;
+  maxRestartsPerHour: number;
+};
+
+export type HarnessHooksConfig = {
+  postIterationCommand: string | null;
+  projectStatusCommand: string | null;
+};
+
+export type HarnessConfig = {
+  supervisor: HarnessSupervisorConfig;
+  hooks: HarnessHooksConfig;
+};
+
+export const harnessConfigPath = path.join(root, "harness.config.json");
+
+function normalizeCommand(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSeconds(value: unknown, fallback: number, minimum = 1): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  return Math.max(Math.round(numeric), minimum);
+}
+
+export function defaultHarnessConfig(): HarnessConfig {
+  return {
+    supervisor: {
+      childCommand: null,
+      workdir: ".",
+      pollIntervalSeconds: 5,
+      restartBackoffSeconds: 10,
+      maxRestartsPerHour: 12,
+    },
+    hooks: {
+      postIterationCommand: null,
+      projectStatusCommand: null,
+    },
+  };
+}
+
+function applyHarnessDefaults(input: Partial<HarnessConfig> | null | undefined): HarnessConfig {
+  const defaults = defaultHarnessConfig();
+  const supervisor: Partial<HarnessSupervisorConfig> = input?.supervisor ?? {};
+  const hooks: Partial<HarnessHooksConfig> = input?.hooks ?? {};
+
+  return {
+    supervisor: {
+      childCommand: normalizeCommand(supervisor.childCommand),
+      workdir:
+        typeof supervisor.workdir === "string" && supervisor.workdir.trim().length > 0
+          ? supervisor.workdir.trim()
+          : defaults.supervisor.workdir,
+      pollIntervalSeconds: normalizeSeconds(
+        supervisor.pollIntervalSeconds,
+        defaults.supervisor.pollIntervalSeconds,
+      ),
+      restartBackoffSeconds: normalizeSeconds(
+        supervisor.restartBackoffSeconds,
+        defaults.supervisor.restartBackoffSeconds,
+      ),
+      maxRestartsPerHour: normalizeSeconds(
+        supervisor.maxRestartsPerHour,
+        defaults.supervisor.maxRestartsPerHour,
+      ),
+    },
+    hooks: {
+      postIterationCommand: normalizeCommand(hooks.postIterationCommand),
+      projectStatusCommand: normalizeCommand(hooks.projectStatusCommand),
+    },
+  };
+}
+
+export async function readHarnessConfig(): Promise<HarnessConfig> {
+  if (!existsSync(harnessConfigPath)) {
+    return defaultHarnessConfig();
+  }
+
+  const raw = await readFile(harnessConfigPath, "utf8");
+  return applyHarnessDefaults(
+    JSON.parse(raw.replace(/^\uFEFF/, "")) as Partial<HarnessConfig>,
+  );
+}
+
+export function resolveHarnessWorkdir(config: HarnessConfig) {
+  return path.resolve(root, config.supervisor.workdir);
+}

--- a/scripts/runtime-shared.ts
+++ b/scripts/runtime-shared.ts
@@ -1,0 +1,203 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { defaultAutonomyConfig, root, type AutonomyConfig, type StopConditionId } from "./project-config";
+
+export type RuntimeState =
+  | "idle"
+  | "starting"
+  | "running"
+  | "stopped"
+  | "completed"
+  | "failed"
+  | "blocked"
+  | "interrupted";
+
+export type HookStatus = {
+  command: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  exitCode: number | null;
+  succeeded: boolean | null;
+  summary: string | null;
+};
+
+export type RuntimeStatus = {
+  state: RuntimeState;
+  workerPid: number | null;
+  activeChildPid: number | null;
+  threadId: string | null;
+  startTime: string | null;
+  lastHeartbeat: string | null;
+  selectedStopCondition: StopConditionId;
+  latestResultSummary: string | null;
+  cycleCount: number;
+  issueExportDirectory: string;
+  stdoutLog: string;
+  stderrLog: string;
+  lastMessageFile: string;
+  runtimeCodexHome: string;
+  environmentMode: "repo-scoped";
+  consecutiveTerminalBlockers: number;
+  lastBlockerSignature: string | null;
+  maxConsecutiveTerminalBlockers: number;
+  lastExitCode: number | null;
+  effectiveSandboxMode: string;
+  lastCycleExecutedRepoCommand: boolean;
+  lastPostIterationHook: HookStatus | null;
+};
+
+export const runtimeDirectory = path.join(root, "data", "runtime");
+export const runtimeStatusPath = path.join(runtimeDirectory, "codex-runtime-status.json");
+export const stdoutLogPath = path.join(runtimeDirectory, "codex-runtime-stdout.log");
+export const stderrLogPath = path.join(runtimeDirectory, "codex-runtime-stderr.log");
+export const lastMessagePath = path.join(runtimeDirectory, "codex-runtime-last-message.txt");
+export const supervisorStatusPath = path.join(runtimeDirectory, "supervisor-status.json");
+
+export function nowIso() {
+  return new Date().toISOString();
+}
+
+export function codexCommand() {
+  if (process.platform !== "win32") {
+    return "codex";
+  }
+
+  try {
+    const resolved = execFileSync("where.exe", ["codex.cmd"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (resolved) {
+      return resolved;
+    }
+  } catch {
+    // fall through to PATH lookup
+  }
+
+  return "codex.cmd";
+}
+
+export function pnpmCommand() {
+  return process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+}
+
+export function tsxEntrypoint() {
+  return path.join(root, "node_modules", "tsx", "dist", "cli.mjs");
+}
+
+export function defaultHookStatus(command: string | null = null): HookStatus {
+  return {
+    command,
+    startedAt: null,
+    finishedAt: null,
+    exitCode: null,
+    succeeded: null,
+    summary: null,
+  };
+}
+
+export function defaultRuntimeStatus(
+  config: AutonomyConfig = defaultAutonomyConfig(),
+): RuntimeStatus {
+  return {
+    state: "idle",
+    workerPid: null,
+    activeChildPid: null,
+    threadId: null,
+    startTime: null,
+    lastHeartbeat: null,
+    selectedStopCondition: config.selectedStopCondition,
+    latestResultSummary: null,
+    cycleCount: 0,
+    issueExportDirectory: config.issueExportDirectory ?? "docs/issues/harness",
+    stdoutLog: path.relative(root, stdoutLogPath),
+    stderrLog: path.relative(root, stderrLogPath),
+    lastMessageFile: path.relative(root, lastMessagePath),
+    runtimeCodexHome: path.relative(root, path.join(runtimeDirectory, "codex-home")),
+    environmentMode: "repo-scoped",
+    consecutiveTerminalBlockers: 0,
+    lastBlockerSignature: null,
+    maxConsecutiveTerminalBlockers: 3,
+    lastExitCode: null,
+    effectiveSandboxMode: config.sandboxMode,
+    lastCycleExecutedRepoCommand: false,
+    lastPostIterationHook: defaultHookStatus(),
+  };
+}
+
+export async function ensureRuntimeDirectory() {
+  await mkdir(runtimeDirectory, { recursive: true });
+}
+
+export async function readRuntimeStatus(config?: AutonomyConfig): Promise<RuntimeStatus> {
+  await ensureRuntimeDirectory();
+  if (!existsSync(runtimeStatusPath)) {
+    return defaultRuntimeStatus(config);
+  }
+
+  const raw = await readFile(runtimeStatusPath, "utf8");
+  const parsed = JSON.parse(raw.replace(/^\uFEFF/, "")) as Partial<RuntimeStatus>;
+  return {
+    ...defaultRuntimeStatus(config),
+    ...parsed,
+    lastPostIterationHook: parsed.lastPostIterationHook
+      ? {
+          ...defaultHookStatus(parsed.lastPostIterationHook.command ?? null),
+          ...parsed.lastPostIterationHook,
+        }
+      : defaultHookStatus(),
+  };
+}
+
+export async function writeRuntimeStatus(status: RuntimeStatus) {
+  await ensureRuntimeDirectory();
+  await writeFile(runtimeStatusPath, `${JSON.stringify(status, null, 2)}\n`, "utf8");
+}
+
+export async function updateRuntimeStatus(
+  updater: (status: RuntimeStatus) => RuntimeStatus | Promise<RuntimeStatus>,
+  config?: AutonomyConfig,
+) {
+  const current = await readRuntimeStatus(config);
+  const next = await updater(current);
+  await writeRuntimeStatus(next);
+  return next;
+}
+
+export function isProcessAlive(pid: number | null): boolean {
+  if (!pid) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function terminateProcess(pid: number | null) {
+  if (!pid) {
+    return;
+  }
+
+  try {
+    if (process.platform === "win32") {
+      execFileSync("taskkill", ["/PID", String(pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+      return;
+    }
+
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // ignore missing processes
+  }
+}

--- a/scripts/runtime.ts
+++ b/scripts/runtime.ts
@@ -11,7 +11,9 @@ import {
   type AutonomyConfig,
   type StopConditionId,
 } from "./project-config";
+import { readHarnessConfig } from "./harness-config";
 import { detectTerminalBlocker, type TerminalBlocker } from "./runtime-blockers";
+import { defaultHookStatus, type HookStatus } from "./runtime-shared";
 
 type RuntimeState =
   | "idle"
@@ -45,6 +47,7 @@ type RuntimeStatus = {
   lastExitCode: number | null;
   effectiveSandboxMode: string;
   lastCycleExecutedRepoCommand: boolean;
+  lastPostIterationHook: HookStatus | null;
 };
 
 type TaskBoardTask = {
@@ -142,6 +145,7 @@ function defaultStatus(config: AutonomyConfig = defaultAutonomyConfig()): Runtim
     lastExitCode: null,
     effectiveSandboxMode: config.sandboxMode,
     lastCycleExecutedRepoCommand: false,
+    lastPostIterationHook: defaultHookStatus(),
   };
 }
 
@@ -159,6 +163,12 @@ async function readRuntimeStatus(config?: AutonomyConfig): Promise<RuntimeStatus
   return {
     ...defaultStatus(config),
     ...loaded,
+    lastPostIterationHook: loaded.lastPostIterationHook
+      ? {
+          ...defaultHookStatus(loaded.lastPostIterationHook.command ?? null),
+          ...loaded.lastPostIterationHook,
+        }
+      : defaultHookStatus(),
   };
 }
 
@@ -266,6 +276,141 @@ function formatSummary(text: string | null | undefined): string | null {
 
   const singleLine = text.replace(/\s+/g, " ").trim();
   return singleLine.length > 240 ? `${singleLine.slice(0, 237)}...` : singleLine;
+}
+
+type ShellCommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+async function runShellCommand(
+  command: string,
+  cwd: string,
+  envAdditions: NodeJS.ProcessEnv = {},
+): Promise<ShellCommandResult> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...envAdditions,
+  };
+
+  return await new Promise<ShellCommandResult>((resolve, reject) => {
+    const child = spawn(command, {
+      cwd,
+      env,
+      shell: process.platform === "win32" ? process.env.ComSpec ?? "cmd.exe" : true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      resolve({
+        exitCode: code ?? 1,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+      });
+    });
+  });
+}
+
+function summarizeHookOutput(result: ShellCommandResult): string {
+  const stdoutSummary = formatSummary(result.stdout);
+  const stderrSummary = formatSummary(result.stderr);
+  if (stdoutSummary && stderrSummary) {
+    return `${stdoutSummary} | stderr: ${stderrSummary}`;
+  }
+  if (stdoutSummary) {
+    return stdoutSummary;
+  }
+  if (stderrSummary) {
+    return `stderr: ${stderrSummary}`;
+  }
+  return `Hook exited with code ${result.exitCode}.`;
+}
+
+async function runPostIterationHook(
+  cycleNumber: number,
+  runtimeState: RuntimeState,
+  threadId: string | null,
+  cycleResult: CycleResult,
+  config: AutonomyConfig,
+) {
+  const harnessConfig = await readHarnessConfig();
+  const command = harnessConfig.hooks.postIterationCommand;
+  if (!command) {
+    return;
+  }
+
+  const startedAt = nowIso();
+  await updateRuntimeStatus(
+    (current) => ({
+      ...current,
+      lastHeartbeat: startedAt,
+      lastPostIterationHook: {
+        ...defaultHookStatus(command),
+        command,
+        startedAt,
+      },
+    }),
+    config,
+  );
+
+  try {
+    const result = await runShellCommand(command, root, {
+      HARNESS_ITERATION: String(cycleNumber),
+      HARNESS_RUNTIME_STATE: runtimeState,
+      HARNESS_THREAD_ID: threadId ?? "",
+      HARNESS_LAST_EXIT_CODE: String(cycleResult.exitCode),
+      HARNESS_REPO_COMMAND_EXECUTED: cycleResult.executedRepoCommand ? "1" : "0",
+      HARNESS_REPO_ROOT: root,
+    });
+    const finishedAt = nowIso();
+
+    await updateRuntimeStatus(
+      (current) => ({
+        ...current,
+        lastHeartbeat: finishedAt,
+        lastPostIterationHook: {
+          command,
+          startedAt,
+          finishedAt,
+          exitCode: result.exitCode,
+          succeeded: result.exitCode === 0,
+          summary: summarizeHookOutput(result),
+        },
+      }),
+      config,
+    );
+  } catch (error) {
+    const finishedAt = nowIso();
+    const message = error instanceof Error ? error.message : String(error);
+    await updateRuntimeStatus(
+      (current) => ({
+        ...current,
+        lastHeartbeat: finishedAt,
+        lastPostIterationHook: {
+          command,
+          startedAt,
+          finishedAt,
+          exitCode: null,
+          succeeded: false,
+          summary: formatSummary(message) ?? "Post-iteration hook failed.",
+        },
+      }),
+      config,
+    );
+  }
 }
 
 function actualCodexConfigPath() {
@@ -717,6 +862,16 @@ async function runWorker() {
       config,
     );
 
+    if (cycleResult.exitCode === 0) {
+      await runPostIterationHook(
+        status.cycleCount + 1,
+        nextState,
+        status.threadId,
+        cycleResult,
+        config,
+      );
+    }
+
     if (nextState === "completed" || nextState === "failed" || nextState === "blocked") {
       return;
     }
@@ -835,6 +990,8 @@ async function commandStatus() {
   console.log(`Last cycle executed repo command: ${effectiveStatus.lastCycleExecutedRepoCommand}`);
   console.log(`Terminal blocker streak: ${effectiveStatus.consecutiveTerminalBlockers}/${effectiveStatus.maxConsecutiveTerminalBlockers}`);
   console.log(`Last blocker signature: ${effectiveStatus.lastBlockerSignature ?? "n/a"}`);
+  console.log(`Post-iteration hook: ${effectiveStatus.lastPostIterationHook?.command ?? "n/a"}`);
+  console.log(`Post-iteration hook result: ${effectiveStatus.lastPostIterationHook?.summary ?? "n/a"}`);
   console.log(`Latest result: ${effectiveStatus.latestResultSummary ?? "n/a"}`);
   console.log(`Stdout log: ${effectiveStatus.stdoutLog}`);
   console.log(`Stderr log: ${effectiveStatus.stderrLog}`);

--- a/scripts/supervisor.ts
+++ b/scripts/supervisor.ts
@@ -1,0 +1,633 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { readHarnessConfig, resolveHarnessWorkdir, type HarnessConfig } from "./harness-config";
+import { root } from "./project-config";
+import {
+  ensureRuntimeDirectory,
+  isProcessAlive,
+  nowIso,
+  pnpmCommand,
+  readRuntimeStatus,
+  runtimeStatusPath,
+  supervisorStatusPath,
+  terminateProcess,
+  tsxEntrypoint,
+  writeRuntimeStatus,
+  type RuntimeState,
+  type RuntimeStatus,
+} from "./runtime-shared";
+
+type SupervisorState =
+  | "idle"
+  | "starting"
+  | "running"
+  | "restarting"
+  | "completed"
+  | "failed"
+  | "stopped"
+  | "interrupted";
+
+type SupervisorStatus = {
+  state: SupervisorState;
+  supervisorPid: number | null;
+  startTime: string | null;
+  lastHeartbeat: string | null;
+  restartCount: number;
+  nextLaunchAt: string | null;
+  lastLaunchAt: string | null;
+  lastLaunchCommand: string | null;
+  lastLaunchExitCode: number | null;
+  lastMessage: string | null;
+  pollIntervalSeconds: number;
+  restartBackoffSeconds: number;
+  maxRestartsPerHour: number;
+  childCommand: string | null;
+  workdir: string;
+  runtimeState: RuntimeState | null;
+  runtimeWorkerPid: number | null;
+  runtimeThreadId: string | null;
+  runtimeCycleCount: number;
+  recentRestartTimestamps: string[];
+};
+
+type ShellCommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+};
+
+function defaultSupervisorStatus(config: HarnessConfig): SupervisorStatus {
+  return {
+    state: "idle",
+    supervisorPid: null,
+    startTime: null,
+    lastHeartbeat: null,
+    restartCount: 0,
+    nextLaunchAt: null,
+    lastLaunchAt: null,
+    lastLaunchCommand: config.supervisor.childCommand,
+    lastLaunchExitCode: null,
+    lastMessage: null,
+    pollIntervalSeconds: config.supervisor.pollIntervalSeconds,
+    restartBackoffSeconds: config.supervisor.restartBackoffSeconds,
+    maxRestartsPerHour: config.supervisor.maxRestartsPerHour,
+    childCommand: config.supervisor.childCommand,
+    workdir: resolveHarnessWorkdir(config),
+    runtimeState: null,
+    runtimeWorkerPid: null,
+    runtimeThreadId: null,
+    runtimeCycleCount: 0,
+    recentRestartTimestamps: [],
+  };
+}
+
+async function readSupervisorStatus(config: HarnessConfig): Promise<SupervisorStatus> {
+  await ensureRuntimeDirectory();
+  if (!existsSync(supervisorStatusPath)) {
+    return defaultSupervisorStatus(config);
+  }
+
+  const raw = await readFile(supervisorStatusPath, "utf8");
+  const parsed = JSON.parse(raw.replace(/^\uFEFF/, "")) as Partial<SupervisorStatus>;
+  return {
+    ...defaultSupervisorStatus(config),
+    ...parsed,
+    recentRestartTimestamps: Array.isArray(parsed.recentRestartTimestamps)
+      ? parsed.recentRestartTimestamps.filter((value): value is string => typeof value === "string")
+      : [],
+  };
+}
+
+async function writeSupervisorStatus(status: SupervisorStatus) {
+  await ensureRuntimeDirectory();
+  await writeFile(supervisorStatusPath, `${JSON.stringify(status, null, 2)}\n`, "utf8");
+}
+
+async function updateSupervisorStatus(
+  config: HarnessConfig,
+  updater: (status: SupervisorStatus) => SupervisorStatus | Promise<SupervisorStatus>,
+) {
+  const current = await readSupervisorStatus(config);
+  const next = await updater(current);
+  await writeSupervisorStatus(next);
+  return next;
+}
+
+function sleep(milliseconds: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function normalizeRuntimeState(status: RuntimeStatus): RuntimeState {
+  if ((status.state === "starting" || status.state === "running") && !isProcessAlive(status.workerPid)) {
+    return "interrupted";
+  }
+
+  return status.state;
+}
+
+function summarize(text: string): string | null {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized.length > 240 ? `${normalized.slice(0, 237)}...` : normalized;
+}
+
+async function runShellCommand(command: string, cwd: string, timeoutMs?: number): Promise<ShellCommandResult> {
+  return await new Promise<ShellCommandResult>((resolve, reject) => {
+    const child = spawn(command, {
+      cwd,
+      env: process.env,
+      shell: process.platform === "win32" ? process.env.ComSpec ?? "cmd.exe" : true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let timeout: NodeJS.Timeout | undefined;
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    if (timeoutMs && timeoutMs > 0) {
+      timeout = setTimeout(() => {
+        timedOut = true;
+        terminateProcess(child.pid ?? null);
+      }, timeoutMs);
+    }
+
+    child.once("error", (error) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      reject(error);
+    });
+
+    child.once("close", (code) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      resolve({
+        exitCode: code ?? 1,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        timedOut,
+      });
+    });
+  });
+}
+
+function nextLaunchCommand(config: HarnessConfig, runtimeStatus: RuntimeStatus): string {
+  if (config.supervisor.childCommand) {
+    return config.supervisor.childCommand;
+  }
+
+  const canResume =
+    Boolean(runtimeStatus.threadId) &&
+    ["stopped", "interrupted", "failed", "blocked"].includes(normalizeRuntimeState(runtimeStatus));
+
+  return `${pnpmCommand()} ${canResume ? "runtime:resume" : "runtime:start"}`;
+}
+
+function pruneRestartHistory(timestamps: string[], maxRestartsPerHour: number) {
+  const cutoff = Date.now() - 60 * 60 * 1000;
+  const recent = timestamps.filter((value) => {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) && parsed >= cutoff;
+  });
+
+  return recent.slice(-Math.max(1, maxRestartsPerHour));
+}
+
+async function markRuntimeStopped(summary: string) {
+  const runtimeStatus = await readRuntimeStatus();
+  await writeRuntimeStatus({
+    ...runtimeStatus,
+    state: "stopped",
+    workerPid: null,
+    activeChildPid: null,
+    lastHeartbeat: nowIso(),
+    latestResultSummary: summary,
+  });
+}
+
+async function runSupervisorWorker() {
+  const config = await readHarnessConfig();
+
+  await updateSupervisorStatus(config, (current) => ({
+    ...current,
+    state: "starting",
+    supervisorPid: process.pid,
+    startTime: current.startTime ?? nowIso(),
+    lastHeartbeat: nowIso(),
+    pollIntervalSeconds: config.supervisor.pollIntervalSeconds,
+    restartBackoffSeconds: config.supervisor.restartBackoffSeconds,
+    maxRestartsPerHour: config.supervisor.maxRestartsPerHour,
+    childCommand: config.supervisor.childCommand,
+    workdir: resolveHarnessWorkdir(config),
+    lastMessage: "Supervisor worker is running.",
+  }));
+
+  while (true) {
+    const latestConfig = await readHarnessConfig();
+    const supervisorStatus = await readSupervisorStatus(latestConfig);
+    if (supervisorStatus.state === "stopped") {
+      return;
+    }
+
+    const runtimeStatus = await readRuntimeStatus();
+    const normalizedRuntimeState = normalizeRuntimeState(runtimeStatus);
+    const runtimeAlive = isProcessAlive(runtimeStatus.workerPid);
+
+    if (normalizedRuntimeState === "starting" || (normalizedRuntimeState === "running" && runtimeAlive)) {
+      await writeSupervisorStatus({
+        ...supervisorStatus,
+        state: "running",
+        supervisorPid: process.pid,
+        lastHeartbeat: nowIso(),
+        pollIntervalSeconds: latestConfig.supervisor.pollIntervalSeconds,
+        restartBackoffSeconds: latestConfig.supervisor.restartBackoffSeconds,
+        maxRestartsPerHour: latestConfig.supervisor.maxRestartsPerHour,
+        childCommand: latestConfig.supervisor.childCommand,
+        workdir: resolveHarnessWorkdir(latestConfig),
+        runtimeState: normalizedRuntimeState,
+        runtimeWorkerPid: runtimeStatus.workerPid,
+        runtimeThreadId: runtimeStatus.threadId,
+        runtimeCycleCount: runtimeStatus.cycleCount,
+        lastMessage: `Runtime ${normalizedRuntimeState} and worker is healthy.`,
+      });
+      await sleep(latestConfig.supervisor.pollIntervalSeconds * 1000);
+      continue;
+    }
+
+    if (normalizedRuntimeState === "completed" || normalizedRuntimeState === "stopped") {
+      await writeSupervisorStatus({
+        ...supervisorStatus,
+        state: normalizedRuntimeState === "completed" ? "completed" : "stopped",
+        supervisorPid: process.pid,
+        lastHeartbeat: nowIso(),
+        runtimeState: normalizedRuntimeState,
+        runtimeWorkerPid: runtimeStatus.workerPid,
+        runtimeThreadId: runtimeStatus.threadId,
+        runtimeCycleCount: runtimeStatus.cycleCount,
+        lastMessage:
+          normalizedRuntimeState === "completed"
+            ? "Runtime completed normally; supervisor will exit."
+            : "Runtime stopped by operator; supervisor will exit.",
+      });
+      return;
+    }
+
+    const recentRestartTimestamps = pruneRestartHistory(
+      supervisorStatus.recentRestartTimestamps,
+      latestConfig.supervisor.maxRestartsPerHour,
+    );
+    if (recentRestartTimestamps.length >= latestConfig.supervisor.maxRestartsPerHour) {
+      await writeSupervisorStatus({
+        ...supervisorStatus,
+        state: "failed",
+        supervisorPid: process.pid,
+        lastHeartbeat: nowIso(),
+        runtimeState: normalizedRuntimeState,
+        runtimeWorkerPid: runtimeStatus.workerPid,
+        runtimeThreadId: runtimeStatus.threadId,
+        runtimeCycleCount: runtimeStatus.cycleCount,
+        recentRestartTimestamps,
+        lastMessage: `Restart limit reached (${latestConfig.supervisor.maxRestartsPerHour}/hour).`,
+      });
+      return;
+    }
+
+    const launchCommand = nextLaunchCommand(latestConfig, runtimeStatus);
+    const launchAt = nowIso();
+    await writeSupervisorStatus({
+      ...supervisorStatus,
+      state: supervisorStatus.restartCount === 0 ? "starting" : "restarting",
+      supervisorPid: process.pid,
+      lastHeartbeat: launchAt,
+      lastLaunchAt: launchAt,
+      lastLaunchCommand: launchCommand,
+      lastLaunchExitCode: null,
+      nextLaunchAt: null,
+      pollIntervalSeconds: latestConfig.supervisor.pollIntervalSeconds,
+      restartBackoffSeconds: latestConfig.supervisor.restartBackoffSeconds,
+      maxRestartsPerHour: latestConfig.supervisor.maxRestartsPerHour,
+      childCommand: latestConfig.supervisor.childCommand,
+      workdir: resolveHarnessWorkdir(latestConfig),
+      runtimeState: normalizedRuntimeState,
+      runtimeWorkerPid: runtimeStatus.workerPid,
+      runtimeThreadId: runtimeStatus.threadId,
+      runtimeCycleCount: runtimeStatus.cycleCount,
+      lastMessage: `Launching runtime with "${launchCommand}".`,
+    });
+
+    let launchResult: ShellCommandResult;
+    try {
+      launchResult = await runShellCommand(launchCommand, resolveHarnessWorkdir(latestConfig), 120000);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const nextLaunchAt = new Date(Date.now() + latestConfig.supervisor.restartBackoffSeconds * 1000).toISOString();
+      await writeSupervisorStatus({
+        ...supervisorStatus,
+        state: "restarting",
+        supervisorPid: process.pid,
+        lastHeartbeat: nowIso(),
+        restartCount: supervisorStatus.restartCount + 1,
+        nextLaunchAt,
+        lastLaunchAt: launchAt,
+        lastLaunchCommand: launchCommand,
+        lastLaunchExitCode: null,
+        runtimeState: normalizedRuntimeState,
+        runtimeWorkerPid: runtimeStatus.workerPid,
+        runtimeThreadId: runtimeStatus.threadId,
+        runtimeCycleCount: runtimeStatus.cycleCount,
+        recentRestartTimestamps: [...recentRestartTimestamps, launchAt],
+        lastMessage: summarize(message) ?? "Launch command failed.",
+      });
+      await sleep(latestConfig.supervisor.restartBackoffSeconds * 1000);
+      continue;
+    }
+
+    const restartCount = supervisorStatus.restartCount + 1;
+    const launchSummary = summarize(launchResult.stdout) ?? summarize(launchResult.stderr);
+
+    await writeSupervisorStatus({
+      ...supervisorStatus,
+      state: launchResult.exitCode === 0 ? "running" : "restarting",
+      supervisorPid: process.pid,
+      lastHeartbeat: nowIso(),
+      restartCount,
+      nextLaunchAt:
+        launchResult.exitCode === 0
+          ? null
+          : new Date(Date.now() + latestConfig.supervisor.restartBackoffSeconds * 1000).toISOString(),
+      lastLaunchAt: launchAt,
+      lastLaunchCommand: launchCommand,
+      lastLaunchExitCode: launchResult.exitCode,
+      pollIntervalSeconds: latestConfig.supervisor.pollIntervalSeconds,
+      restartBackoffSeconds: latestConfig.supervisor.restartBackoffSeconds,
+      maxRestartsPerHour: latestConfig.supervisor.maxRestartsPerHour,
+      childCommand: latestConfig.supervisor.childCommand,
+      workdir: resolveHarnessWorkdir(latestConfig),
+      runtimeState: normalizedRuntimeState,
+      runtimeWorkerPid: runtimeStatus.workerPid,
+      runtimeThreadId: runtimeStatus.threadId,
+      runtimeCycleCount: runtimeStatus.cycleCount,
+      recentRestartTimestamps: [...recentRestartTimestamps, launchAt],
+      lastMessage:
+        launchResult.exitCode === 0
+          ? launchSummary ?? "Launch command completed successfully."
+          : launchSummary ?? `Launch command exited with code ${launchResult.exitCode}.`,
+    });
+
+    if (launchResult.exitCode !== 0) {
+      await sleep(latestConfig.supervisor.restartBackoffSeconds * 1000);
+      continue;
+    }
+
+    await sleep(Math.min(2000, latestConfig.supervisor.pollIntervalSeconds * 1000));
+  }
+}
+
+async function commandStart() {
+  const config = await readHarnessConfig();
+  const status = await readSupervisorStatus(config);
+  if (
+    ["starting", "running", "restarting"].includes(status.state) &&
+    isProcessAlive(status.supervisorPid)
+  ) {
+    console.log("Runtime supervisor is already active.");
+    return;
+  }
+
+  const seededStatus: SupervisorStatus = {
+    ...defaultSupervisorStatus(config),
+    state: "starting",
+    startTime: nowIso(),
+    lastHeartbeat: nowIso(),
+    lastMessage: "Starting detached runtime supervisor.",
+  };
+  await writeSupervisorStatus(seededStatus);
+
+  const child = spawn(process.execPath, [tsxEntrypoint(), path.join(root, "scripts", "supervisor.ts"), "worker"], {
+    cwd: root,
+    detached: true,
+    stdio: "ignore",
+    env: process.env,
+  });
+  child.unref();
+
+  await writeSupervisorStatus({
+    ...seededStatus,
+    supervisorPid: child.pid ?? null,
+    lastHeartbeat: nowIso(),
+    lastMessage: "Runtime supervisor started in background.",
+  });
+
+  console.log("Runtime supervisor started in background.");
+}
+
+async function commandStatus() {
+  const config = await readHarnessConfig();
+  const runtimeStatus = await readRuntimeStatus();
+  const status = await readSupervisorStatus(config);
+  const supervisorAlive = isProcessAlive(status.supervisorPid);
+  const effectiveStatus =
+    ["starting", "running", "restarting"].includes(status.state) && !supervisorAlive
+      ? {
+          ...status,
+          state: "interrupted" as const,
+          runtimeState: normalizeRuntimeState(runtimeStatus),
+          runtimeWorkerPid: runtimeStatus.workerPid,
+          runtimeThreadId: runtimeStatus.threadId,
+          runtimeCycleCount: runtimeStatus.cycleCount,
+          lastMessage: status.lastMessage ?? "Supervisor process is no longer running.",
+        }
+      : status;
+
+  if (effectiveStatus !== status) {
+    await writeSupervisorStatus(effectiveStatus);
+  }
+
+  console.log(`Supervisor state: ${effectiveStatus.state}`);
+  console.log(`Supervisor PID: ${effectiveStatus.supervisorPid ?? "n/a"}`);
+  console.log(`Supervisor alive: ${supervisorAlive}`);
+  console.log(`Started: ${effectiveStatus.startTime ?? "n/a"}`);
+  console.log(`Last heartbeat: ${effectiveStatus.lastHeartbeat ?? "n/a"}`);
+  console.log(`Restarts: ${effectiveStatus.restartCount}`);
+  console.log(`Next launch at: ${effectiveStatus.nextLaunchAt ?? "n/a"}`);
+  console.log(`Last launch at: ${effectiveStatus.lastLaunchAt ?? "n/a"}`);
+  console.log(`Last launch command: ${effectiveStatus.lastLaunchCommand ?? "n/a"}`);
+  console.log(`Last launch exit code: ${effectiveStatus.lastLaunchExitCode ?? "n/a"}`);
+  console.log(`Poll interval: ${effectiveStatus.pollIntervalSeconds}s`);
+  console.log(`Restart backoff: ${effectiveStatus.restartBackoffSeconds}s`);
+  console.log(`Max restarts/hour: ${effectiveStatus.maxRestartsPerHour}`);
+  console.log(`Runtime state: ${effectiveStatus.runtimeState ?? normalizeRuntimeState(runtimeStatus)}`);
+  console.log(`Runtime worker PID: ${effectiveStatus.runtimeWorkerPid ?? runtimeStatus.workerPid ?? "n/a"}`);
+  console.log(`Runtime thread ID: ${effectiveStatus.runtimeThreadId ?? runtimeStatus.threadId ?? "n/a"}`);
+  console.log(`Runtime cycles: ${effectiveStatus.runtimeCycleCount || runtimeStatus.cycleCount}`);
+  console.log(`Workdir: ${effectiveStatus.workdir}`);
+  console.log(`Status file: ${path.relative(root, supervisorStatusPath)}`);
+  console.log(`Runtime status file: ${path.relative(root, runtimeStatusPath)}`);
+  console.log(`Message: ${effectiveStatus.lastMessage ?? "n/a"}`);
+}
+
+async function commandStop() {
+  const config = await readHarnessConfig();
+  const status = await readSupervisorStatus(config);
+
+  terminateProcess(status.supervisorPid);
+  await markRuntimeStopped("Runtime stopped by operator through supervisor control.");
+
+  await writeSupervisorStatus({
+    ...status,
+    state: "stopped",
+    supervisorPid: null,
+    lastHeartbeat: nowIso(),
+    nextLaunchAt: null,
+    runtimeState: "stopped",
+    runtimeWorkerPid: null,
+    lastMessage: "Supervisor stopped by operator.",
+  });
+
+  console.log("Runtime supervisor stopped.");
+}
+
+async function projectStatusSection(config: HarnessConfig): Promise<string | null> {
+  const command = config.hooks.projectStatusCommand;
+  if (!command) {
+    return null;
+  }
+
+  try {
+    const result = await runShellCommand(command, root, 15000);
+    const heading = `Project status command: ${command}`;
+    if (result.timedOut) {
+      return `${heading}\nTimed out after 15s.`;
+    }
+    if (result.exitCode !== 0) {
+      return `${heading}\nExit code ${result.exitCode}\n${result.stderr || result.stdout || "No output."}`;
+    }
+    return `${heading}\n${result.stdout || "(no output)"}`;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `Project status command: ${command}\nFailed: ${message}`;
+  }
+}
+
+function formatHookLine(runtimeStatus: RuntimeStatus) {
+  const hook = runtimeStatus.lastPostIterationHook;
+  if (!hook?.command) {
+    return "Post-iteration hook: not configured";
+  }
+
+  return `Post-iteration hook: ${hook.command} | ok=${hook.succeeded ?? "n/a"} | exit=${hook.exitCode ?? "n/a"} | summary=${hook.summary ?? "n/a"}`;
+}
+
+async function renderWatchOutput() {
+  const config = await readHarnessConfig();
+  const supervisorStatus = await readSupervisorStatus(config);
+  const runtimeStatus = await readRuntimeStatus();
+  const supervisorAlive = isProcessAlive(supervisorStatus.supervisorPid);
+  const runtimeAlive = isProcessAlive(runtimeStatus.workerPid);
+  const projectSection = await projectStatusSection(config);
+
+  const lines = [
+    "Codex Harness Watch",
+    `Time: ${new Date().toLocaleString()}`,
+    "",
+    `Supervisor: ${supervisorStatus.state} | pid=${supervisorStatus.supervisorPid ?? "n/a"} | alive=${supervisorAlive} | restarts=${supervisorStatus.restartCount}`,
+    `Heartbeat: ${supervisorStatus.lastHeartbeat ?? "n/a"} | next launch=${supervisorStatus.nextLaunchAt ?? "n/a"}`,
+    `Launch: ${supervisorStatus.lastLaunchCommand ?? "n/a"} | exit=${supervisorStatus.lastLaunchExitCode ?? "n/a"}`,
+    `Supervisor message: ${supervisorStatus.lastMessage ?? "n/a"}`,
+    "",
+    `Runtime: ${normalizeRuntimeState(runtimeStatus)} | worker=${runtimeStatus.workerPid ?? "n/a"} | alive=${runtimeAlive} | child=${runtimeStatus.activeChildPid ?? "n/a"}`,
+    `Thread: ${runtimeStatus.threadId ?? "n/a"} | cycles=${runtimeStatus.cycleCount} | last exit=${runtimeStatus.lastExitCode ?? "n/a"}`,
+    `Stop condition: ${runtimeStatus.selectedStopCondition} | sandbox=${runtimeStatus.effectiveSandboxMode}`,
+    `Latest result: ${runtimeStatus.latestResultSummary ?? "n/a"}`,
+    formatHookLine(runtimeStatus),
+  ];
+
+  if (projectSection) {
+    lines.push("", projectSection);
+  }
+
+  lines.push(
+    "",
+    `Harness config: ${path.relative(root, path.join(root, "harness.config.json"))}`,
+    `Supervisor status: ${path.relative(root, supervisorStatusPath)}`,
+    `Runtime status: ${path.relative(root, runtimeStatusPath)}`,
+  );
+
+  return lines.join("\n");
+}
+
+async function commandWatch() {
+  const args = new Set(process.argv.slice(3));
+  const once = args.has("--once");
+  const config = await readHarnessConfig();
+
+  do {
+    console.clear();
+    console.log(await renderWatchOutput());
+    if (once) {
+      return;
+    }
+    await sleep(config.supervisor.pollIntervalSeconds * 1000);
+  } while (true);
+}
+
+async function main() {
+  await ensureRuntimeDirectory();
+  const command = process.argv[2] ?? "status";
+
+  switch (command) {
+    case "start":
+      await commandStart();
+      return;
+    case "status":
+      await commandStatus();
+      return;
+    case "stop":
+      await commandStop();
+      return;
+    case "watch":
+      await commandWatch();
+      return;
+    case "worker":
+      await runSupervisorWorker();
+      return;
+    default:
+      throw new Error(`Unknown supervisor command "${command}".`);
+  }
+}
+
+main().catch(async (error) => {
+  const config = await readHarnessConfig().catch(() => null);
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (config) {
+    await updateSupervisorStatus(config, (current) => ({
+      ...current,
+      state: "failed",
+      supervisorPid: current.supervisorPid === process.pid ? null : current.supervisorPid,
+      lastHeartbeat: nowIso(),
+      lastMessage: summarize(message) ?? "Supervisor failed.",
+    })).catch(() => undefined);
+  }
+
+  console.error(message);
+  process.exitCode = 1;
+});

--- a/scripts/supervisor.ts
+++ b/scripts/supervisor.ts
@@ -487,7 +487,10 @@ async function commandStatus() {
 async function commandStop() {
   const config = await readHarnessConfig();
   const status = await readSupervisorStatus(config);
+  const runtimeStatus = await readRuntimeStatus();
 
+  terminateProcess(runtimeStatus.activeChildPid);
+  terminateProcess(runtimeStatus.workerPid);
   terminateProcess(status.supervisorPid);
   await markRuntimeStopped("Runtime stopped by operator through supervisor control.");
 


### PR DESCRIPTION
## Summary
- add a generic outer runtime supervisor that relaunches interrupted runtime workers
- add `pnpm runtime:watch` plus `harness.config.json` for generic supervisor and hook configuration
- add optional `hooks.postIterationCommand` and `hooks.projectStatusCommand` so downstream repos can extend watch/restart behavior without forking template logic

## Why
This upstreams the restart/watch layer from downstream experimentation into Foundry while keeping the template generic. Poword-specific milestone and task-board rendering remains downstream via hooks rather than being hardcoded into the template.

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm typecheck`
- smoke-tested the supervisor by launching a dummy runtime worker, killing it, and confirming automatic relaunch
- validated downstream Poword restart recovery by killing the active runtime worker and confirming the supervisor resumed the runtime on the same thread

## Downstream Note
Poword-specific milestone and task-board display stays downstream via `hooks.projectStatusCommand`; the upstream template only provides generic supervisor/watch primitives.